### PR TITLE
Fix bug about IFS when no conditions match and else clause is missing in ruby 3.1

### DIFF
--- a/lib/xls_function/evaluators/functions/ifs.rb
+++ b/lib/xls_function/evaluators/functions/ifs.rb
@@ -13,6 +13,8 @@ module XlsFunction
           arg_list.each_slice(2) do |expr, value|
             return value&.evaluate(context) if expr&.evaluate(context)
           end
+
+          nil
         end
       end
     end

--- a/spec/e2e/ifs_spec.rb
+++ b/spec/e2e/ifs_spec.rb
@@ -14,5 +14,12 @@ RSpec.describe XlsFunction do
 
       it { is_expected.to eq('true2') }
     end
+
+    context 'when cond1 and cond2 returns false' do
+      let(:cond1) { '1 = 2' }
+      let(:cond2) { '0 > 1' }
+
+      it { is_expected.to be_nil }
+    end
   end
 end


### PR DESCRIPTION
# Background

Fix bug 

- https://github.com/moneyforward/xls_function/issues/7

# Cause
`each_slice` returns `nil` in ruby 3.0.x, but returns `self` in ruby 3.1.x

- https://bugs.ruby-lang.org/issues/18268

# Changes

Fix IFS `eval` function returns nil not self.