### PR TITLE
Returns "#DIV/0!" as XlsFunction::ErrorValue when zero division occurs

### DIFF
--- a/lib/xls_function/error.rb
+++ b/lib/xls_function/error.rb
@@ -34,12 +34,18 @@ module XlsFunction
       def na(error_info = '')
         new(ERROR_NA, error_info)
       end
+
+      # @return #DIV/0!
+      def div0!(error_info = '')
+        new(ERROR_DIV0, error_info)
+      end
     end
   end
 
   ERROR_VALUE = '#VALUE!'.freeze
   ERROR_NUM = '#NUM!'.freeze
   ERROR_NA = '#N/A'.freeze
+  ERROR_DIV0 = '#DIV/0!'.freeze
 
   ERRORS = [
     ERROR_VALUE,

--- a/lib/xls_function/evaluators/binary_operations/divide.rb
+++ b/lib/xls_function/evaluators/binary_operations/divide.rb
@@ -5,7 +5,16 @@ module XlsFunction
         operator_as '/'
 
         def eval
+          return ::XlsFunction::ErrorValue.div0!(divide_by_zero) if right.zero?
+
           left / right
+        end
+
+        private
+
+        def divide_by_zero
+          message = error_message(:cannot_divide_by_zero)
+          class_info(message)
         end
       end
     end

--- a/lib/xls_function/locales/en.yml
+++ b/lib/xls_function/locales/en.yml
@@ -64,4 +64,5 @@ en:
       cannot_convert_to_number: Cannot convert %{source} to number.
       cannot_convert_to_date: Cannot convert %{source} to date.
       cannot_convert_to_time: Cannot convert %{source} to time.
+      cannot_divide_by_zero: "Cannot divide by zero."
       invalid_value_for_function: Invalid value for formula or function.

--- a/lib/xls_function/locales/ja.yml
+++ b/lib/xls_function/locales/ja.yml
@@ -64,4 +64,5 @@ ja:
       cannot_convert_to_number: "%{source}は数値に変換できません。"
       cannot_convert_to_date: "%{source}は日付に変換できません。"
       cannot_convert_to_time: "%{source}は時刻に変換できません。"
+      cannot_divide_by_zero: "0除算が発生しました。"
       invalid_value_for_function: 値が数式または関数に対して無効です。

--- a/spec/transform_rules/binary_operations/divide_spec.rb
+++ b/spec/transform_rules/binary_operations/divide_spec.rb
@@ -1,8 +1,21 @@
 RSpec.describe XlsFunction::Transform do
   subject { described_class.new.apply(obj, context).evaluate }
 
-  let(:obj) { { left: { number: '9' }, operator: '/', right: { number: '3' } } }
-  let(:context) { nil }
+  context 'when right is not zero' do
+    let(:obj) { { left: { number: '9' }, operator: '/', right: { number: '3' } } }
+    let(:context) { nil }
 
-  it { is_expected.to eq(3) }
+    it { is_expected.to eq(3) }
+  end
+
+  context 'when right is zero' do
+    let(:obj) { { left: { number: '9' }, operator: '/', right: { number: '0' } } }
+    let(:context) { nil }
+
+    it do
+      is_expected.to be_error
+        .and be_is_a(XlsFunction::ErrorValue)
+        .and eq("#DIV/0!")
+    end
+  end
 end


### PR DESCRIPTION
# Background
When zero division occurs, XlsFunction#evaluate returns Infinity object.

```
$ bin/console 
irb(main):001:0> XlsFunction.evaluate("1/0")
=> Infinity
```

However, in that case, XlsFunction#evaluate should return "#DIV/0!" as Excel-like Function Evaluator.

# Changes
- When zero division occurs, XlsFunction#evaluate returns "#DIV/0!" as XlsFunction::ErrorValue.
- Add divide_spec.