### PR TITLE
Fix parse error of compartion operator

### DIFF
--- a/lib/xls_function/parse_rules/binary_operation.rb
+++ b/lib/xls_function/parse_rules/binary_operation.rb
@@ -7,7 +7,7 @@ module XlsFunction
           rule(:multiple_divide_operator) { match['*/'].as(:operator) >> space? }
           rule(:plus_minus_opeartor) { match['+-'].as(:operator) >> space? }
           rule(:concat_opeartor) { str('&').as(:operator) >> space? }
-          rule(:comparison_operator) { (str('>') | str('>=') | str('<') | str('<=') | str('=') | str('<>')).as(:operator) >> space? }
+          rule(:comparison_operator) { (str('<>') | str('>=') | str('<=') | str('>') | str('<') | str('=')).as(:operator) >> space? }
 
           rule(:binary_operation) do
             infix_expression(

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -68,6 +68,30 @@ RSpec.describe XlsFunction::Parser do
         right: { number: '2' }
       )
     end
+
+    it '= operator parse' do
+      is_expected.to parse('1 = 1').as(left: { number: '1' }, operator: '=', right: { number: '1' })
+    end
+
+    it '<> operator parse' do
+      is_expected.to parse('1 <> 1').as(left: { number: '1' }, operator: '<>', right: { number: '1' })
+    end
+
+    it '< operator parse' do
+      is_expected.to parse('1 < 1').as(left: { number: '1' }, operator: '<', right: { number: '1' })
+    end
+
+    it '<= operator parse' do
+      is_expected.to parse('1 <= 1').as(left: { number: '1' }, operator: '<=', right: { number: '1' })
+    end
+
+    it '> operator parse' do
+      is_expected.to parse('1 > 1').as(left: { number: '1' }, operator: '>', right: { number: '1' })
+    end
+
+    it '>= operator parse' do
+      is_expected.to parse('1 >= 1').as(left: { number: '1' }, operator: '>=', right: { number: '1' })
+    end
   end
 
   describe 'function call with variant' do


### PR DESCRIPTION
# BackGround

Operators `<>`, `<=`, and `>=` fail to parse.

Here are results of additional test before the fix

```rb
Failures:

  1) XlsFunction::Parser binary operation comparison operator: <>
     Failure/Error: is_expected.to parse('1 <> 1').as(left: { number: '1' }, operator: '<>', right: { number: '1' })
       expected output of parsing "1 <> 1" with EXPRESSION to equal {:left=>{:number=>"1"}, :operator=>"<>", :right=>{:number=>"1"}}, but was nil
     # ./spec/parser_spec.rb:77:in `block (3 levels) in <top (required)>'

  2) XlsFunction::Parser binary operation comparison operator: <=
     Failure/Error: is_expected.to parse('1 <= 1').as(left: { number: '1' }, operator: '<=', right: { number: '1' })
       expected output of parsing "1 <= 1" with EXPRESSION to equal {:left=>{:number=>"1"}, :operator=>"<=", :right=>{:number=>"1"}}, but was nil
     # ./spec/parser_spec.rb:85:in `block (3 levels) in <top (required)>'

  3) XlsFunction::Parser binary operation comparison operator: >=
     Failure/Error: is_expected.to parse('1 >= 1').as(left: { number: '1' }, operator: '>=', right: { number: '1' })
       expected output of parsing "1 >= 1" with EXPRESSION to equal {:left=>{:number=>"1"}, :operator=>">=", :right=>{:number=>"1"}}, but was nil
     # ./spec/parser_spec.rb:93:in `block (3 levels) in <top (required)>'

Finished in 0.21389 seconds (files took 0.36222 seconds to load)
279 examples, 3 failures

Failed examples:

rspec ./spec/parser_spec.rb:76 # XlsFunction::Parser binary operation comparison operator: <>
rspec ./spec/parser_spec.rb:84 # XlsFunction::Parser binary operation comparison operator: <=
rspec ./spec/parser_spec.rb:92 # XlsFunction::Parser binary operation comparison operator: >=
```

# Changes

- Add parse test of comparison operators.
- Fixed collation order of operators when parsing.