### PR TITLE
Added `-Z1` to change full-width spaces to half-width spaces

### DIFF
--- a/lib/xls_function/evaluators/functions/asc.rb
+++ b/lib/xls_function/evaluators/functions/asc.rb
@@ -9,7 +9,7 @@ module XlsFunction
         define_arg :source
 
         def eval
-          NKF.nkf('-w -Z4 -x --ic=UTF-8 --oc=UTF-8', source)
+          NKF.nkf('-w -Z1 -Z4 -x --ic=UTF-8 --oc=UTF-8', source)
         end
       end
     end

--- a/spec/e2e/asc_spec.rb
+++ b/spec/e2e/asc_spec.rb
@@ -53,5 +53,13 @@ RSpec.describe XlsFunction do
         is_expected.to eq('㈱ ｴｸｾﾙ ｴｸｾﾙ') # Only 1-byte spaces
       end
     end
+
+    context 'when the string is English' do
+      let!(:string) { 'Hello, world!' }
+
+      it 'doesn\'t convert' do
+        is_expected.to eq('Hello, world!')
+      end
+    end
   end
 end

--- a/spec/e2e/asc_spec.rb
+++ b/spec/e2e/asc_spec.rb
@@ -21,5 +21,37 @@ RSpec.describe XlsFunction do
         is_expected.to eq('㈱ ｴｸｾﾙ')
       end
     end
+
+    context 'when the string contains 2-byte spaces' do
+      let!(:string) { '㈱　エクセル' } # Note the 2-byte space between characters
+
+      it 'converts 2-byte spaces to 1-byte spaces' do
+        is_expected.to eq('㈱ ｴｸｾﾙ') # Note the 1-byte space between characters
+      end
+    end
+
+    context 'when the string is empty' do
+      let!(:string) { '' }
+
+      it 'returns an empty string' do
+        is_expected.to eq('')
+      end
+    end
+
+    context 'when the string contains only 2-byte spaces' do
+      let!(:string) { '　　' } # Only 2-byte spaces
+
+      it 'converts 2-byte spaces to 1-byte spaces' do
+        is_expected.to eq('  ') # Only 1-byte spaces
+      end
+    end
+
+    context 'when the string contains a mix of 1-byte and 2-byte spaces' do
+      let!(:string) { '㈱　エクセル ｴｸｾﾙ' } # Mix of 1-byte and 2-byte spaces
+
+      it 'converts only 2-byte spaces to 1-byte spaces' do
+        is_expected.to eq('㈱ ｴｸｾﾙ ｴｸｾﾙ') # Only 1-byte spaces
+      end
+    end
   end
 end


### PR DESCRIPTION
## Background
- A problem occurred where full-width spaces could not be converted to half-width spaces.
- I have added a fix to the ASC function to solve this problem.

## Change
- Added `-Z1` option for ruby's nfk.(ref: https://docs.ruby-lang.org/ja/latest/class/NKF.html)

- rspec result before add `-Z1`

```ruby
$ bundle exec rspec spec/e2e/asc_spec.rb
warning: parser/current is loading parser/ruby31, which recognizes 3.1.6-compliant syntax, but you are running 3.1.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
..F.FF

Failures:

  1) XlsFunction ASC when the string contains 2-byte spaces converts 2-byte spaces to 1-byte spaces
     Failure/Error: is_expected.to eq('㈱ ｴｸｾﾙ') # Note the 1-byte space between characters
     
       expected: "㈱ ｴｸｾﾙ"
            got: "㈱　ｴｸｾﾙ"
     
       (compared using ==)
     # ./spec/e2e/asc_spec.rb:29:in `block (4 levels) in <top (required)>'

  2) XlsFunction ASC when the string contains only 2-byte spaces converts 2-byte spaces to 1-byte spaces
     Failure/Error: is_expected.to eq('  ') # Only 1-byte spaces
     
       expected: "  "
            got: "　　"
     
       (compared using ==)
     # ./spec/e2e/asc_spec.rb:45:in `block (4 levels) in <top (required)>'

  3) XlsFunction ASC when the string contains a mix of 1-byte and 2-byte spaces converts only 2-byte spaces to 1-byte spaces
     Failure/Error: is_expected.to eq('㈱ ｴｸｾﾙ ｴｸｾﾙ') # Only 1-byte spaces
     
       expected: "㈱ ｴｸｾﾙ ｴｸｾﾙ"
            got: "㈱　ｴｸｾﾙ ｴｸｾﾙ"
     
       (compared using ==)
     # ./spec/e2e/asc_spec.rb:53:in `block (4 levels) in <top (required)>'

Finished in 0.02357 seconds (files took 2.75 seconds to load)
6 examples, 3 failures

Failed examples:

rspec ./spec/e2e/asc_spec.rb:28 # XlsFunction ASC when the string contains 2-byte spaces converts 2-byte spaces to 1-byte spaces
rspec ./spec/e2e/asc_spec.rb:44 # XlsFunction ASC when the string contains only 2-byte spaces converts 2-byte spaces to 1-byte spaces
rspec ./spec/e2e/asc_spec.rb:52 # XlsFunction ASC when the string contains a mix of 1-byte and 2-byte spaces converts only 2-byte spaces to 1-byte spaces
```

- after add `-Z1`

```ruby
> XlsFunction.evaluate('ASC("　")')
=> " "
> XlsFunction.evaluate('ASC("ああ　aaa AAA")')
=> "ああ aaa AAA"
```
